### PR TITLE
Deprecated 'rlang()' in favor of 't()' function for translation

### DIFF
--- a/pincore/functions/base.php
+++ b/pincore/functions/base.php
@@ -78,11 +78,11 @@ if (!function_exists('lang')) {
     }
 }
 
-if (!function_exists('rlang')) {
+if (!function_exists('rlang(')) {
     /**
      * @deprecated Use the 't()' function instead, which provides the same functionality.
      */
-    function t($key, array $replace = [], $locale = NULL, $fallback = true)
+    function rlang($key, array $replace = [], $locale = NULL, $fallback = true)
     {
         return Lang::get($key, $replace, $locale, $fallback);
     }


### PR DESCRIPTION
Fix pull request #51 