### PR TITLE
feat: add Pinroll and harden local core path fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ sample-dev-app.pinx
 /apps/*/pinx/
 /apps/*/export/
 
+# Pinroll project config
+/pinroll/
+
 
 # =============================================================================
 # Project — PHP & Composer

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "nunomaduro/collision": "^8.5",
     "pestphp/pest": "^2.36",
     "pinoox/devdb": "^1.4",
+    "pinoox/pinroll": "^1.0.5",
     "pinoox/pinx-inspector": "^1.3"
   },
   "scripts": {

--- a/platform/launcher/core-path.php
+++ b/platform/launcher/core-path.php
@@ -68,7 +68,11 @@ function pinoox_resolve_configured_core_path(string $basePath): string
     }
 
     if (!empty($configuredPath)) {
-        return pinoox_resolve_relative_core_path($basePath, $configuredPath);
+        $resolved = pinoox_resolve_relative_core_path($basePath, $configuredPath);
+        if (pinoox_is_valid_core_path($resolved)) {
+            return $resolved;
+        }
+        // Local .pincore (e.g. ../pincore3) must not break production vendor installs.
     }
 
     $localCore = pinoox_detect_local_core_path($basePath);


### PR DESCRIPTION
Require pinoox/pinroll, ignore project pinroll/ config, and keep production vendor/pincore when a local .pincore path is invalid.