### PR TITLE
fix: autoload pincore helpers via Composer files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,5 +135,17 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 # Security
 BCRYPT_ROUNDS=12
 
+# Optional server auto-login for local/dev only (manual). CLI does not set this.
+# Multiple lines OK — each request uses the line matching the active app package.
+# PINOOX_LOGIN=com_pinoox_manager:id:1
+# PINOOX_LOGIN=com_pinoox_manager:user_id:1
+# PINOOX_LOGIN=com_pinoox_manager:personal_id:1
+# PINOOX_LOGIN=com_pinoox_account:username:yoosef
+# PINOOX_LOGIN=com_pinoox_app:email:info@pinoox.com
+# PINOOX_LOGIN=com_pinoox_shop:mobile:09122220000
+
+# CLI token auto-login (written by: user:login --force, cleared by: user:logout --force)
+# PINOOX_LOGIN_TOKEN=
+
 # Domain routing (optional)
 # PINOOX_DOMAIN=https://example.com

--- a/platform/launcher/bootstrap.php
+++ b/platform/launcher/bootstrap.php
@@ -31,9 +31,6 @@ define('PINOOX_START', microtime(true));
 |
 */
 
-
-require_once PINOOX_CORE_PATH . 'functions/base.php';
-
 $loader = require PINOOX_BASE_PATH . '/vendor/autoload.php';
 
 if ($loader instanceof Composer\Autoload\ClassLoader) {

--- a/platform/pinoox.config.php
+++ b/platform/pinoox.config.php
@@ -11,6 +11,6 @@ return [
     | Kernel version: pincore/config/pincore.config.php
     |
     */
-    'version_code' => 47,
-    'version_name' => '3.3.6',
+    'version_code' => 50,
+    'version_name' => '3.3.9',
 ];


### PR DESCRIPTION
## Summary
- Register `functions/base.php` in pincore Composer `autoload.files`
- Drop manual `require` from platform and pincore launchers
- Require pincore `^3.7.5` in the app template

## Why
Helpers were missing in CLI (`php pinoox` / pinx) when `app.php` called them.

## Test plan
- [x] `composer dump-autoload` then `function_exists('app')` via `vendor/autoload.php`
- [x] `php pinoox list` boots without helper fatals
- [x] Single-app (`packages/app`) boots and helpers resolve