### PR TITLE
chore: bump pincore to 3.8.3 and platform to 3.3.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "pinoox/pincore": "^3.4"
+    "pinoox/pincore": "^3.8.3"
   },
   "autoload": {
     "psr-4": {

--- a/platform/pinoox.config.php
+++ b/platform/pinoox.config.php
@@ -11,6 +11,6 @@ return [
     | Kernel version: pincore/config/pincore.config.php
     |
     */
-    'version_code' => 51,
-    'version_name' => '3.3.10',
+    'version_code' => 52,
+    'version_name' => '3.3.11',
 ];


### PR DESCRIPTION
## Summary
- Bump `pinoox/pincore` to `^3.8.3`
- Release platform `3.3.11` (`version_code` 52) and tag `v3.3.11`

## Test plan
- [ ] `composer install` resolves `pinoox/pincore` `v3.8.3`
- [ ] App boots and CLI runs against the new core
- [ ] Platform version reports as `3.3.11`