### PR TITLE
chore: require pinroll in production and bump to 3.3.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   ],
   "require": {
     "php": "^8.2",
-    "pinoox/pincore": "^3.8.4"
+    "pinoox/pincore": "^3.8",
+    "pinoox/pinroll": "^1.1"
   },
   "autoload": {
     "psr-4": {
@@ -32,7 +33,6 @@
     "nunomaduro/collision": "^8.5",
     "pestphp/pest": "^2.36",
     "pinoox/devdb": "^1.4",
-    "pinoox/pinroll": "^1.1.0",
     "pinoox/pinx-inspector": "^1.3"
   },
   "scripts": {

--- a/platform/pinoox.config.php
+++ b/platform/pinoox.config.php
@@ -11,6 +11,6 @@ return [
     | Kernel version: pincore/config/pincore.config.php
     |
     */
-    'version_code' => 53,
-    'version_name' => '3.3.12',
+    'version_code' => 54,
+    'version_name' => '3.3.13',
 ];


### PR DESCRIPTION
Move pinoox/pinroll into Composer require so host vendor packs keep PinGate, and bump platform version_code/name.