### PR TITLE
fix: installer ApiResource Request signature and manager app-view JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,9 @@ APP_ENV=development
 # MODE=production
 # APP_DEBUG defaults: production=false, other modes=true — set explicitly to override
 # APP_DEBUG=false
-# Pinoox Exception page (independent of APP_DEBUG) — defaults to true in all modes
-# PINOOX_EXCEPTION=true
+# Rich Pinoox Exception page (independent of APP_DEBUG). Defaults to true in all modes.
+# Production: set false for a friendly "something went wrong" page / generic JSON (no stack traces).
+# PINOOX_EXCEPTION=false
 APP_KEY=
 APP_URL=http://localhost
 APP_LOCALE=en

--- a/apps/com_pinoox_installer/Resource/AgreementResource.php
+++ b/apps/com_pinoox_installer/Resource/AgreementResource.php
@@ -3,14 +3,14 @@
 namespace App\com_pinoox_installer\Resource;
 
 use Pinoox\Component\Http\Api\ApiResource;
+use Pinoox\Component\Http\Request;
 
 final class AgreementResource extends ApiResource
 {
-    public function toArray(): array
+    public function toArray(Request $request): array
     {
         return [
             'text' => (string) $this->resource,
         ];
     }
 }
-

--- a/apps/com_pinoox_installer/Resource/LangResource.php
+++ b/apps/com_pinoox_installer/Resource/LangResource.php
@@ -3,10 +3,11 @@
 namespace App\com_pinoox_installer\Resource;
 
 use Pinoox\Component\Http\Api\ApiResource;
+use Pinoox\Component\Http\Request;
 
 final class LangResource extends ApiResource
 {
-    public function toArray(): array
+    public function toArray(Request $request): array
     {
         $payload = is_array($this->resource) ? $this->resource : [];
 
@@ -16,4 +17,3 @@ final class LangResource extends ApiResource
         ];
     }
 }
-

--- a/apps/com_pinoox_installer/Resource/PingResource.php
+++ b/apps/com_pinoox_installer/Resource/PingResource.php
@@ -3,10 +3,11 @@
 namespace App\com_pinoox_installer\Resource;
 
 use Pinoox\Component\Http\Api\ApiResource;
+use Pinoox\Component\Http\Request;
 
 final class PingResource extends ApiResource
 {
-    public function toArray(): array
+    public function toArray(Request $request): array
     {
         return [
             'ok' => true,
@@ -15,4 +16,3 @@ final class PingResource extends ApiResource
         ];
     }
 }
-

--- a/apps/com_pinoox_manager/Controller/AppViewController.php
+++ b/apps/com_pinoox_manager/Controller/AppViewController.php
@@ -2,9 +2,9 @@
 
 /**
  *      ****  *  *     *  ****  ****  *    *
- *      *  *  *  * *   *  *  *  *  *   *  *
- *      ****  *  *  *  *  *  *  *  *    *
- *      *     *  *   * *  *  *  *  *   *  *
+ *      *  *  * *   *  *  *  *   *  *
+ *      ****  *  *  *  *  *  *  *    *
+ *      *     *  *   * *  *  *  *   *  *
  *      *     *  *    **  ****  ****  *    *
  * @author   Pinoox
  * @link https://www.pinoox.com/
@@ -33,7 +33,8 @@ class AppViewController
 
         $managerToken = $request->queryOne('__manager_token');
         if (is_string($managerToken) && $managerToken !== '') {
-            Auth::setRequestToken($managerToken);
+            $tokenKey = $this->resolveTokenKeyFromJwt($managerToken);
+            Auth::setRequestToken($tokenKey ?? $managerToken);
         }
 
         if (!Auth::check()) {
@@ -83,6 +84,34 @@ class AppViewController
         return Auth::check();
     }
 
+    /**
+     * Decode a manager JWT and return the inner token_key.
+     * The JWT payload is keyed by the active auth.cookie name (e.g. manager_pinoox).
+     */
+    private function resolveTokenKeyFromJwt(string $jwt): ?string
+    {
+        if (!class_exists('Firebase\\JWT\\JWT')) {
+            return null;
+        }
+
+        try {
+            $config = \Pinoox\Component\User\AuthConfig::resolve(refresh: false);
+            $secret = (string) ($config['jwt_secret'] ?? '');
+            $keyName = (string) ($config['key'] ?? '');
+
+            if ($secret === '' || $keyName === '') {
+                return null;
+            }
+
+            $payload = (array) \Firebase\JWT\JWT::decode($jwt, new \Firebase\JWT\Key($secret, 'HS256'));
+            $value = $payload[$keyName] ?? reset($payload);
+
+            return is_string($value) && $value !== '' ? $value : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
     private function canPreview(string $packageName): bool
     {
         if (!AppEngine::exists($packageName))
@@ -117,4 +146,3 @@ class AppViewController
         ]);
     }
 }
-

--- a/apps/com_pinoox_manager/theme/spark/src/views/components/widgets/Menu.vue
+++ b/apps/com_pinoox_manager/theme/spark/src/views/components/widgets/Menu.vue
@@ -1,20 +1,37 @@
 <template>
   <div class="toolbarMenu">
-    <Icon :is="icon" class="toolbarMenu__icon" size="sm"/>
+    <Icon :is="iconComponent" class="toolbarMenu__icon" size="sm"/>
     <span class="toolbarMenu__label">{{ label }}</span>
   </div>
 </template>
 
 <script setup>
+import { computed, markRaw } from 'vue';
 
 const props = defineProps({
   icon: {
-    type: String,
+    type: [String, Object, Function],
     default: null,
   },
   label: {
     type: String,
     required: true,
   },
+});
+
+const iconComponent = computed(() => {
+    if (!props.icon) {
+        return null;
+    }
+
+    if (typeof props.icon === 'string') {
+        return props.icon;
+    }
+
+    if (typeof props.icon === 'function' || typeof props.icon === 'object') {
+        return markRaw(props.icon);
+    }
+
+    return props.icon;
 });
 </script>

--- a/apps/com_pinoox_manager/theme/spark/src/views/pages/control/apps/apps-home.vue
+++ b/apps/com_pinoox_manager/theme/spark/src/views/pages/control/apps/apps-home.vue
@@ -1,13 +1,13 @@
 <template>
   <Page title="اپلیکیشن‌ها" class="pageApps">
     <template #toolbar>
-      <Menu @click="openModalInstallApp" :icon="saxIcon.add" label="نصب اپلکیشن"/>
-      <Menu @click="openMarket()" :icon="saxIcon.market" label="مارکت"/>
+      <Menu @click="openModalInstallApp" :icon="icons.add" label="نصب اپلکیشن"/>
+      <Menu @click="openMarket()" :icon="icons.market" label="مارکت"/>
     </template>
 
     <div v-if="stagedCount" class="pageApps__stagedEntry">
       <button type="button" class="pageApps__stagedBtn" @click="openStagedModal">
-        <Icon :is="saxIcon.upload" size="sm"/>
+        <Icon :is="icons.upload" size="sm"/>
         <span>بسته‌های آپلود شده</span>
         <span class="pageApps__stagedBadge">{{ stagedCount }}</span>
       </button>
@@ -33,13 +33,13 @@
         v-else-if="!stagedCount"
         title="هیچ اپلیکیشنی نصب نشده"
         description="برای افزودن اپلیکیشن جدید، روی دکمه نصب کلیک کنید."
-        :icon="saxIcon.apps"
+        :icon="icons.apps"
     />
   </Page>
 </template>
 
 <script setup>
-import {computed, onMounted, ref, watch} from 'vue';
+import {computed, markRaw, onMounted, ref, watch} from 'vue';
 import {openModal} from '@kolirt/vue-modal';
 import {saxIcon} from '@/const/icons.js';
 import {appAPI} from '@api/app.js';
@@ -57,6 +57,13 @@ const packageInstallerStore = usePackageInstallerStore();
 const {pushAppManager} = useControlPanelNavigation();
 const {openMarket} = useMarket();
 const stagedFiles = ref([]);
+
+const icons = markRaw({
+    add: saxIcon.add,
+    market: saxIcon.market,
+    upload: saxIcon.upload,
+    apps: saxIcon.apps,
+});
 
 const stagedCount = computed(() => stagedFiles.value.length);
 

--- a/apps/com_pinoox_manager/theme/spark/src/views/pages/control/control-sidebar.vue
+++ b/apps/com_pinoox_manager/theme/spark/src/views/pages/control/control-sidebar.vue
@@ -24,8 +24,8 @@
       <LucideIcon :name="isMenuCollapsed ? lucideSidebar.chevronLeft : lucideSidebar.chevronRight" size="sm"/>
     </template>
 
-    <template #icon>
-      <LucideIcon :name="lucideSidebar.chevronLeft" size="sm"/>
+    <template #icon="{ iconClass, item }">
+      <LucideIcon :name="resolveIconName(item)" size="sm"/>
     </template>
   </sidebar-menu>
 </template>
@@ -38,7 +38,7 @@ import {lucideSidebar} from '../../../const/icons.js';
 import LucideIcon from '../../components/widgets/LucideIcon.vue';
 import {useSidebarStore} from '../../composables/useSidebar.js';
 import {useControlPanelLayoutStore} from '@/stores/modules/controlPanelLayout.js';
-import {toSidebarMenuItems} from '@/views/pages/control/controlMenuItems.js';
+import {controlMenuItems, toSidebarMenuItems} from '@/views/pages/control/controlMenuItems.js';
 import ControlPanelSidebarLink from '@/views/pages/control/ControlPanelSidebarLink.vue';
 import {isControlPanelMemoryPath} from '@/router/controlPanelMemoryRouter.js';
 import {useControlPanelNavigation} from '@/views/composables/useControlPanelNavigation.js';
@@ -54,7 +54,26 @@ const sidebar = useSidebarStore();
 const layout = useControlPanelLayoutStore();
 const {pushControlPath} = useControlPanelNavigation();
 
-const menuItems = ref(toSidebarMenuItems(LucideIcon));
+const iconNameMap = new Map(controlMenuItems.map((item) => [item.title, item.iconName]));
+
+const resolveIconName = (item) => {
+    if (!item) {
+        return lucideSidebar.menu;
+    }
+
+    const byTitle = iconNameMap.get(item.title);
+    if (byTitle) {
+        return byTitle;
+    }
+
+    if (item.title === 'کنترل پنل' || item.iconClass?.includes('toggle')) {
+        return isMenuCollapsed.value ? lucideSidebar.chevronLeft : lucideSidebar.chevronRight;
+    }
+
+    return lucideSidebar.menu;
+};
+
+const menuItems = ref(toSidebarMenuItems());
 
 const isMenuCollapsed = computed(() => sidebar.isCollapsed && !layout.isCompact);
 const showSidebar = computed(() => !layout.isCompact || layout.mobileSidebarOpen);

--- a/apps/com_pinoox_manager/theme/spark/src/views/pages/control/controlMenuItems.js
+++ b/apps/com_pinoox_manager/theme/spark/src/views/pages/control/controlMenuItems.js
@@ -1,4 +1,4 @@
-import {lucideSidebar} from '@/const/icons.js';
+import { lucideSidebar } from '@/const/icons.js';
 
 export const controlMenuItems = [
     {
@@ -47,30 +47,18 @@ export const controlMenuItems = [
     },
 ];
 
-export function menuIconComponent(LucideIcon, name) {
-    return {
-        element: LucideIcon,
-        attributes: {name},
-    };
-}
-
-export function toSidebarMenuItems(LucideIcon) {
+export function toSidebarMenuItems() {
     return controlMenuItems.map((item) => {
+        const base = {
+            title: item.title,
+            attributes: { 'aria-label': item.title },
+        };
+
         if (item.children) {
-            return {
-                title: item.title,
-                icon: menuIconComponent(LucideIcon, item.iconName),
-                attributes: {'aria-label': item.title},
-                child: item.children.map((child) => ({...child})),
-            };
+            return { ...base, child: item.children.map((child) => ({ ...child })) };
         }
 
-        return {
-            href: item.href,
-            title: item.title,
-            icon: menuIconComponent(LucideIcon, item.iconName),
-            attributes: {'aria-label': item.title},
-        };
+        return { ...base, href: item.href };
     });
 }
 


### PR DESCRIPTION
## Summary
- Align installer `ApiResource::toArray()` with pincore’s `toArray(Request $request)` so setup no longer fatals after kernel upgrade.
- Decode manager JWT to the inner `token_key` in app-view preview, and tidy related control menu/sidebar UI.

## Changes
### Installer
- Update `PingResource`, `LangResource`, and `AgreementResource` to accept `Request $request`.

### Manager
- Resolve JWT payload → `token_key` before `Auth::setRequestToken()` in `AppViewController`.
- Adjust spark control menu / sidebar / apps-home icon and menu wiring.

## Test plan
- [ ] Open installer setup page after pincore ≥ 3.8 (no `toArray()` fatal)
- [ ] Complete or re-open installer routes that return ping / lang / agreement resources
- [ ] From Manager, open app-view preview for an installed app while logged in
- [ ] Confirm preview auth still works with manager JWT cookie/header
- [ ] Smoke-check control sidebar and apps home menu icons/labels